### PR TITLE
feat: グリッドリサイズUIをボタンに変更

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,17 +14,29 @@
 <body class="light">
     <h1>グリッドエディタ</h1>
 
-    <div class="controls">
-        <label for="rows">行数:</label>
-        <input type="number" id="rows" value="10" min="1">
-        <label for="cols">列数:</label>
-        <input type="number" id="cols" value="10" min="1">
-        <button id="resize-btn">サイズ変更</button>
+    <div class="editor-area">
+        <div class="top-controls">
+            <button id="add-row-top" title="上に行を追加">+</button>
+            <button id="remove-row-top" title="上の行を削除">-</button>
+        </div>
+        <div class="middle-controls">
+            <div class="left-controls">
+                <button id="add-col-left" title="左に列を追加">+</button><br>
+                <button id="remove-col-left" title="左の列を削除">-</button>
+            </div>
+            <div id="game-wrapper">
+                <div id="game"></div>
+            </div>
+            <div class="right-controls">
+                <button id="add-col-right" title="右に列を追加">+</button><br>
+                <button id="remove-col-right" title="右の列を削除">-</button>
+            </div>
+        </div>
+        <div class="bottom-controls">
+            <button id="add-row-bottom" title="下に行を追加">+</button>
+            <button id="remove-row-bottom" title="下の行を削除">-</button>
+        </div>
     </div>
-
-	<div id="game-wrapper">
-		<div id="game"></div>
-	</div>
 
     <div class="export-controls">
         <button id="export-btn">エクスポート</button>

--- a/public/assets/scss/_page.scss
+++ b/public/assets/scss/_page.scss
@@ -12,10 +12,45 @@ h1 {
     color: var(--main);
 }
 
-.controls, .export-controls {
+.export-controls {
     display: flex;
     gap: 10px;
     align-items: center;
+}
+
+.editor-area {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 5px;
+}
+
+.middle-controls {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 5px;
+}
+
+.top-controls, .bottom-controls {
+    display: flex;
+    justify-content: center;
+    gap: 5px;
+}
+
+.left-controls, .right-controls {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    gap: 5px;
+}
+
+.editor-area button {
+    width: 30px;
+    height: 30px;
+    font-size: 16px;
+    font-weight: bold;
+    cursor: pointer;
 }
 
 #game-wrapper {

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,5 @@
 const gameWrapper = document.getElementById('game-wrapper')!;
 const gameContainer = document.getElementById('game')!;
-const rowsInput = document.getElementById('rows') as HTMLInputElement;
-const colsInput = document.getElementById('cols') as HTMLInputElement;
 
 const CELL_SIZE = 40;
 
@@ -122,41 +120,65 @@ class Grid {
         }
     }
 
-    resize(newRows: number, newCols: number) {
-        const newCellStates = Array(newRows).fill(null).map(() => Array(newCols).fill(CellState.EMPTY));
-        const newHorizontalBorders = Array(newRows + 1).fill(null).map(() => Array(newCols).fill(false));
-        const newVerticalBorders = Array(newRows).fill(null).map(() => Array(newCols + 1).fill(false));
+    addRow(position: 'top' | 'bottom') {
+        this.rows++;
+        const newCellRow = Array(this.cols).fill(CellState.EMPTY);
+        const newHorizontalBorderRow = Array(this.cols).fill(false);
+        const newVerticalBorderRow = Array(this.cols + 1).fill(false);
 
-        const rowsToCopy = Math.min(this.rows, newRows);
-        const colsToCopy = Math.min(this.cols, newCols);
-
-        // Copy cell states
-        for (let i = 0; i < rowsToCopy; i++) {
-            for (let j = 0; j < colsToCopy; j++) {
-                newCellStates[i][j] = this.cellStates[i][j];
-            }
+        if (position === 'top') {
+            this.cellStates.unshift(newCellRow);
+            this.horizontalBorders.unshift(newHorizontalBorderRow);
+            this.verticalBorders.unshift(newVerticalBorderRow);
+        } else { // bottom
+            this.cellStates.push(newCellRow);
+            this.horizontalBorders.push(newHorizontalBorderRow);
+            this.verticalBorders.push(newVerticalBorderRow);
         }
+        this.render();
+    }
 
-        // Copy horizontal borders
-        for (let i = 0; i < Math.min(this.rows + 1, newRows + 1); i++) {
-            for (let j = 0; j < colsToCopy; j++) {
-                newHorizontalBorders[i][j] = this.horizontalBorders[i][j];
-            }
+    removeRow(position: 'top' | 'bottom') {
+        if (this.rows <= 1) return;
+        this.rows--;
+        if (position === 'top') {
+            this.cellStates.shift();
+            this.horizontalBorders.shift();
+            this.verticalBorders.shift();
+        } else { // bottom
+            this.cellStates.pop();
+            this.horizontalBorders.pop();
+            this.verticalBorders.pop();
         }
+        this.render();
+    }
 
-        // Copy vertical borders
-        for (let i = 0; i < rowsToCopy; i++) {
-            for (let j = 0; j < Math.min(this.cols + 1, newCols + 1); j++) {
-                newVerticalBorders[i][j] = this.verticalBorders[i][j];
-            }
+    addCol(position: 'left' | 'right') {
+        this.cols++;
+        if (position === 'left') {
+            this.cellStates.forEach(row => row.unshift(CellState.EMPTY));
+            this.horizontalBorders.forEach(row => row.unshift(false));
+            this.verticalBorders.forEach(row => row.unshift(false));
+        } else { // right
+            this.cellStates.forEach(row => row.push(CellState.EMPTY));
+            this.horizontalBorders.forEach(row => row.push(false));
+            this.verticalBorders.forEach(row => row.push(false));
         }
+        this.render();
+    }
 
-        this.rows = newRows;
-        this.cols = newCols;
-        this.cellStates = newCellStates;
-        this.horizontalBorders = newHorizontalBorders;
-        this.verticalBorders = newVerticalBorders;
-
+    removeCol(position: 'left' | 'right') {
+        if (this.cols <= 1) return;
+        this.cols--;
+        if (position === 'left') {
+            this.cellStates.forEach(row => row.shift());
+            this.horizontalBorders.forEach(row => row.shift());
+            this.verticalBorders.forEach(row => row.shift());
+        } else { // right
+            this.cellStates.forEach(row => row.pop());
+            this.horizontalBorders.forEach(row => row.pop());
+            this.verticalBorders.forEach(row => row.pop());
+        }
         this.render();
     }
 
@@ -233,17 +255,21 @@ class Grid {
 let grid: Grid;
 
 function initialize() {
-    const initialRows = parseInt(rowsInput.value, 10);
-    const initialCols = parseInt(colsInput.value, 10);
-    grid = new Grid(initialRows, initialCols);
+    grid = new Grid(10, 10); // Start with a default 10x10 grid
     grid.render();
 
-    const resizeBtn = document.getElementById('resize-btn')!;
-    resizeBtn.addEventListener('click', () => {
-        const newRows = parseInt(rowsInput.value, 10);
-        const newCols = parseInt(colsInput.value, 10);
-        grid.resize(newRows, newCols);
-    });
+    // Add/Remove Row buttons
+    document.getElementById('add-row-top')!.addEventListener('click', () => grid.addRow('top'));
+    document.getElementById('remove-row-top')!.addEventListener('click', () => grid.removeRow('top'));
+    document.getElementById('add-row-bottom')!.addEventListener('click', () => grid.addRow('bottom'));
+    document.getElementById('remove-row-bottom')!.addEventListener('click', () => grid.removeRow('bottom'));
+
+    // Add/Remove Col buttons
+    document.getElementById('add-col-left')!.addEventListener('click', () => grid.addCol('left'));
+    document.getElementById('remove-col-left')!.addEventListener('click', () => grid.removeCol('left'));
+    document.getElementById('add-col-right')!.addEventListener('click', () => grid.addCol('right'));
+    document.getElementById('remove-col-right')!.addEventListener('click', () => grid.removeCol('right'));
+
 
     const exportBtn = document.getElementById('export-btn')!;
     const exportOutput = document.getElementById('export-output') as HTMLTextAreaElement;


### PR DESCRIPTION
ユーザーのフィードバックに基づき、グリッドのサイズ変更方法を改善します。

- 従来の数値入力フィールドと「サイズ変更」ボタンを廃止しました。
- グリッドの上下左右に「+」と「-」ボタンを配置し、直感的に行と列を追加・削除できるようにしました。
- `Grid`クラスに`addRow`, `removeRow`, `addCol`, `removeCol`メソッドを実装し、新しいUIに対応するロジックを構築しました。
- 新しいUIレイアウトに合わせてCSSを更新しました。