### PR TITLE
feat: インポート機能と未エンコード文字列の表示機能を追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,9 +38,24 @@
         </div>
     </div>
 
-    <div class="export-controls">
-        <button id="export-btn">エクスポート</button>
-        <textarea id="export-output" readonly rows="4" cols="50"></textarea>
+    <div class="io-controls">
+        <div class="import-controls">
+            <h3>インポート</h3>
+            <textarea id="import-input" rows="4" cols="50" placeholder="ここに盤面データを貼り付け"></textarea>
+            <button id="import-btn">インポート</button>
+        </div>
+        <div class="export-controls">
+            <h3>エクスポート</h3>
+            <button id="export-btn">エクスポート</button>
+            <div class="output-group">
+                <label for="pre-base64-output">元データ:</label>
+                <textarea id="pre-base64-output" readonly rows="2" cols="50"></textarea>
+            </div>
+            <div class="output-group">
+                <label for="export-output">Base64:</label>
+                <textarea id="export-output" readonly rows="2" cols="50"></textarea>
+            </div>
+        </div>
     </div>
 
 	<script type="module" src="./src/main.ts"></script>

--- a/public/assets/scss/_page.scss
+++ b/public/assets/scss/_page.scss
@@ -109,3 +109,25 @@ h1 {
     width: 7px;
     transform: translateX(-3px);
 }
+
+.io-controls {
+    display: flex;
+    gap: 40px;
+    margin-top: 20px;
+    width: 100%;
+    justify-content: center;
+    align-items: flex-start;
+}
+
+.import-controls, .export-controls {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
+    align-items: flex-start;
+}
+
+.output-group {
+    display: flex;
+    flex-direction: column;
+    gap: 5px;
+}


### PR DESCRIPTION
ユーザーのフィードバックに基づき、インポートとエクスポート機能を拡張します。

- インポート機能: エクスポートされたBase64文字列をテキストエリアに貼り付けて「インポート」ボタンを押すことで、盤面の状態を復元できるようになりました。
- 未エンコード文字列の表示: エクスポート時に、Base64にエンコードされる前のバイナリ文字列（可読性は低い）も表示し、データ構造の確認ができるようにしました。
- UIの更新: 新しい機能に対応するためにHTMLとCSSを更新しました。